### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - '8'
   - '9'
   - '10'
   - '11'


### PR DESCRIPTION
### Motivation
- Currently, node 8 has [no more support](https://blog.risingstack.com/update-nodejs-8-end-of-life-no-support/).


